### PR TITLE
fix: exclude @cloudflare/workers-types from pnpm minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 overrides:
   esbuild: '>=0.28.1'
+
+# Cloudflare publishes workers-types daily; exclude from the 24h release-age gate.
+minimumReleaseAgeExclude:
+  - '@cloudflare/workers-types'


### PR DESCRIPTION
## Summary
- Fix Cloudflare Workers deploy CI failure caused by pnpm 11's default 24h `minimumReleaseAge` policy
- Exclude `@cloudflare/workers-types` from the release-age gate since Cloudflare publishes this package daily

## Test plan
- [x] `pnpm install --frozen-lockfile` passes locally
- [ ] Cloudflare Workers deploy workflow succeeds on merge

Made with [Cursor](https://cursor.com)