### PR TITLE
fix: allow esbuild, sharp, and workerd build scripts for pnpm 11

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,8 @@ overrides:
 # Cloudflare publishes workers-types daily; exclude from the 24h release-age gate.
 minimumReleaseAgeExclude:
   - '@cloudflare/workers-types'
+
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## Summary
- Add `allowBuilds` entries for `esbuild`, `sharp`, and `workerd` in `pnpm-workspace.yaml`
- Fixes CI failure `ERR_PNPM_IGNORED_BUILDS` after upgrading to pnpm 11, which enables `strictDepBuilds` by default

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds on a clean `node_modules`
- [x] `pnpm run docs:build` succeeds
- [ ] CI workflows pass after merge
